### PR TITLE
Enhancement: handle lower error rates (#5)

### DIFF
--- a/dgim/dgim.py
+++ b/dgim/dgim.py
@@ -13,12 +13,15 @@ class Dgim(object):
     http://infolab.stanford.edu/~ullman/mmds/ch4.pdf
     """
 
-    def __init__(self, N):
+    def __init__(self, N, r=2):
         """Constructor
         :param N: size of the sliding window
         :type N: int
+        :param r: the maximum number of buckets of the same size
+        :type r: int
         """
         self.N = N
+        self.r = r
         self.buckets = []
         self.timestamp = 0
 
@@ -43,13 +46,13 @@ class Dgim(object):
                 crt_buckets = [reminder] + list(crt_buckets)
             else:
                 crt_buckets = list(crt_buckets)
-            if len(crt_buckets) <= 2:
+            if len(crt_buckets) <= self.r:
                 reminder = None
                 new_buckets.extend(crt_buckets)
-            elif len(crt_buckets) == 3:
-                new_buckets.append(crt_buckets[0])
-                crt_buckets[1].merge(crt_buckets[2])
-                reminder = crt_buckets[1]
+            elif len(crt_buckets) == self.r + 1:
+                new_buckets.extend(crt_buckets[:-2])
+                crt_buckets[-2].merge(crt_buckets[-1])
+                reminder = crt_buckets[-2]
             else:
                 raise ValueError("Too many elements")
         if reminder is not None:

--- a/dgim/dgim.py
+++ b/dgim/dgim.py
@@ -25,6 +25,16 @@ class Dgim(object):
         self.buckets = []
         self.timestamp = 0
 
+    @property
+    def error_rate(self):
+        """Return the maximum error rate made by the algorithm.
+        Let c be the true result and e the estimate returned by the dgim
+        algorithm.
+        abs(c-e) < error_rate * c
+        :returns: float
+        """
+        return 1/float(self.r)
+
     def update(self, elt):
         """Update the stream with one element.
         The element can be either 0 or 1.

--- a/dgim/dgim.py
+++ b/dgim/dgim.py
@@ -21,6 +21,8 @@ class Dgim(object):
         :type r: int
         """
         self.N = N
+        if r < 2:
+            raise ValueError("'r' should be higher or equal to 2. Got {}.".format(r))
         self.r = r
         self.buckets = []
         self.timestamp = 0

--- a/tests/test_dgim.py
+++ b/tests/test_dgim.py
@@ -78,3 +78,10 @@ class TestDgim(unittest.TestCase):
         for elt in itertools.repeat(0, 1000):
             dgim.update(elt)
             self.assertEqual(0, dgim.get_count())
+
+    def test_error_rate(self):
+        dgim = Dgim(10, 2)
+        self.assertEqual(0.5, dgim.error_rate)
+
+        dgim = Dgim(10, 10)
+        self.assertEqual(0.1, dgim.error_rate)

--- a/tests/test_dgim.py
+++ b/tests/test_dgim.py
@@ -1,5 +1,5 @@
 import unittest
-
+import itertools
 from dgim.dgim import Dgim, Bucket
 
 
@@ -72,3 +72,9 @@ class TestDgim(unittest.TestCase):
         self.assertEquals(3, len(dgim.buckets))
         dgim.update(0)
         self.assertEquals(2, len(dgim.buckets))
+
+    def test_only_zeros(self):
+        dgim = Dgim(10)
+        for elt in itertools.repeat(0, 1000):
+            dgim.update(elt)
+            self.assertEqual(0, dgim.get_count())

--- a/tests/test_dgim.py
+++ b/tests/test_dgim.py
@@ -85,3 +85,6 @@ class TestDgim(unittest.TestCase):
 
         dgim = Dgim(10, 10)
         self.assertEqual(0.1, dgim.error_rate)
+
+    def test_invalid_r(self):
+        self.assertRaises(ValueError, Dgim, 10, 1)

--- a/tests/test_dgim_quality.py
+++ b/tests/test_dgim_quality.py
@@ -1,5 +1,6 @@
 import unittest
 import random
+import itertools
 from dgim.dgim import Dgim
 
 class ExactAlgorithm(object):
@@ -91,3 +92,7 @@ class TestDgimQuality(unittest.TestCase):
     def test_low_error_rate_case(self):
         stream = generate_random_stream(length=1000)
         self.check_quality_settings(N=100, r=100, stream=stream, max_error_rate=0.01)
+
+    def test_only_ones_case(self):
+        stream = itertools.repeat(1, 10000)
+        self.check_quality_settings(N=100, r=2, stream=stream, max_error_rate=0.5)

--- a/tests/test_dgim_quality.py
+++ b/tests/test_dgim_quality.py
@@ -43,7 +43,7 @@ def generate_random_stream(length):
 
 class TestDgimQuality(unittest.TestCase):
 
-    def check_quality_settings(self, N, r, stream, max_error_rate):
+    def check_quality_settings(self, N, r, stream):
         """Compare the result "e" returned by dgim with the exact result
         "c" on a stream which elements are 0 or 1.
         The test fails if the dgim result "e" is not in the expected bounds.
@@ -55,8 +55,6 @@ class TestDgimQuality(unittest.TestCase):
         :type r: int
         :param stream: the stream to use. It should contains only 0 or 1 as elements.
         :type stream: iterator
-        :param max_error_rate: the theoretical maximum error rate
-        :type max_error_rate: float
         """
         dgim = Dgim(N, r)
         exact_algorithm = ExactAlgorithm(N)
@@ -66,33 +64,33 @@ class TestDgimQuality(unittest.TestCase):
 
             exact_result = exact_algorithm.get_count()
             error = abs(dgim.get_count() - exact_result)
-            self.assertTrue(error <= max_error_rate * exact_result)
+            self.assertTrue(error <= dgim.error_rate * exact_result)
 
     def test_nominal_case(self):
         stream = generate_random_stream(length=1000)
-        self.check_quality_settings(N=100, r=2, stream=stream, max_error_rate=0.5)
+        self.check_quality_settings(N=100, r=2, stream=stream)
 
     def test_large_N(self):
         stream = generate_random_stream(length=2000)
-        self.check_quality_settings(N=10000, r=2, stream=stream, max_error_rate=0.5)
+        self.check_quality_settings(N=10000, r=2, stream=stream)
 
     def test_short_stream(self):
         # stream is shorter than N
         stream = generate_random_stream(length=100)
-        self.check_quality_settings(N=1000, r=2, stream=stream, max_error_rate=0.5)
+        self.check_quality_settings(N=1000, r=2, stream=stream)
 
     def test_N_is_one(self):
         stream = generate_random_stream(length=10)
-        self.check_quality_settings(N=1, r=2, stream=stream, max_error_rate=0.5)
+        self.check_quality_settings(N=1, r=2, stream=stream)
 
     def test_N_is_two(self):
         stream = generate_random_stream(length=100)
-        self.check_quality_settings(N=2, r=2, stream=stream, max_error_rate=0.5)
+        self.check_quality_settings(N=2, r=2, stream=stream)
 
     def test_low_error_rate_case(self):
         stream = generate_random_stream(length=1000)
-        self.check_quality_settings(N=100, r=100, stream=stream, max_error_rate=0.01)
+        self.check_quality_settings(N=100, r=100, stream=stream)
 
     def test_only_ones_case(self):
         stream = itertools.repeat(1, 10000)
-        self.check_quality_settings(N=100, r=2, stream=stream, max_error_rate=0.5)
+        self.check_quality_settings(N=100, r=2, stream=stream)

--- a/tests/test_dgim_quality.py
+++ b/tests/test_dgim_quality.py
@@ -30,20 +30,21 @@ class ExactAlgorithm(object):
         return sum(self.sliding_window)
 
 
+def generate_random_stream(length):
+    """Generate a random stream of zeros and ones.
+    :param length: the stream length
+    :type length: int
+    :returns: iterator
+    """
+    for i in range(length):
+        yield random.randint(0, 1)
+
+
 class TestDgimQuality(unittest.TestCase):
 
-    def generate_random_stream(self, length):
-        """Generate a random stream of zeros and ones.
-        :param length: the stream length
-        :type length: int
-        :returns: iterator
-        """
-        for i in range(length):
-            yield random.randint(0, 1)
-
-    def check_quality_settings(self, N, r, stream_length, max_error_rate):
+    def check_quality_settings(self, N, r, stream, max_error_rate):
         """Compare the result "e" returned by dgim with the exact result
-        "c" on a random stream.
+        "c" on a stream which elements are 0 or 1.
         The test fails if the dgim result "e" is not in the expected bounds.
         0.5 * c <= e <= 1.5 * c
 
@@ -51,14 +52,14 @@ class TestDgimQuality(unittest.TestCase):
         :type N: int
         :param r: the maximum number of buckets of the same size
         :type r: int
-        :param stream_length: the length of the random stream
-        :type stream_length: int
+        :param stream: the stream to use. It should contains only 0 or 1 as elements.
+        :type stream: iterator
         :param max_error_rate: the theoretical maximum error rate
         :type max_error_rate: float
         """
         dgim = Dgim(N, r)
         exact_algorithm = ExactAlgorithm(N)
-        for elt in self.generate_random_stream(stream_length):
+        for elt in stream:
             dgim.update(elt)
             exact_algorithm.update(elt)
 
@@ -67,20 +68,26 @@ class TestDgimQuality(unittest.TestCase):
             self.assertTrue(error <= max_error_rate * exact_result)
 
     def test_nominal_case(self):
-        self.check_quality_settings(N=100, r=2, stream_length=1000, max_error_rate=0.5)
+        stream = generate_random_stream(length=1000)
+        self.check_quality_settings(N=100, r=2, stream=stream, max_error_rate=0.5)
 
     def test_large_N(self):
-        self.check_quality_settings(N=10000, r=2, stream_length=20000, max_error_rate=0.5)
+        stream = generate_random_stream(length=2000)
+        self.check_quality_settings(N=10000, r=2, stream=stream, max_error_rate=0.5)
 
     def test_short_stream(self):
         # stream is shorter than N
-        self.check_quality_settings(N=1000, r=2, stream_length=100, max_error_rate=0.5)
+        stream = generate_random_stream(length=100)
+        self.check_quality_settings(N=1000, r=2, stream=stream, max_error_rate=0.5)
 
     def test_N_is_one(self):
-        self.check_quality_settings(N=1, r=2, stream_length=10, max_error_rate=0.5)
+        stream = generate_random_stream(length=10)
+        self.check_quality_settings(N=1, r=2, stream=stream, max_error_rate=0.5)
 
     def test_N_is_two(self):
-        self.check_quality_settings(N=2, r=2, stream_length=100, max_error_rate=0.5)
+        stream = generate_random_stream(length=100)
+        self.check_quality_settings(N=2, r=2, stream=stream, max_error_rate=0.5)
 
     def test_low_error_rate_case(self):
-        self.check_quality_settings(N=100, r=100, stream_length=1000, max_error_rate=0.01)
+        stream = generate_random_stream(length=1000)
+        self.check_quality_settings(N=100, r=100, stream=stream, max_error_rate=0.01)


### PR DESCRIPTION
Add a `r` parameter to `Dgim` constructor. The higher it is, the lower the error rate.

Fix #5 
