### PR TITLE
Enhancement: use module for timestamps (#4)

### DIFF
--- a/dgim/dgim.py
+++ b/dgim/dgim.py
@@ -79,7 +79,7 @@ class Dgim(object):
             last = queue.pop()
             second_last = queue.pop()
             # merge last two buckets.
-            reminder = max(last, second_last)
+            reminder = second_last
 
     def is_bucket_too_old(self, bucket_timestamp):
         """Check if a bucket is too old and should be dropped.

--- a/dgim/dgim.py
+++ b/dgim/dgim.py
@@ -64,7 +64,7 @@ class Dgim(object):
         """
         self.timestamp += 1
         #check if oldest bucket should be removed
-        if self.is_oldest_bucket_too_old():
+        if self.is_bucket_too_old(self.get_oldest_bucket_timestamp()):
             self.drop_oldest_bucket()
         if elt != 1:
             #nothing to do
@@ -80,13 +80,14 @@ class Dgim(object):
             # merge last two buckets.
             reminder = max(last, second_last)
 
-    def is_oldest_bucket_too_old(self):
-        """Check if the latest bucket is too old and should be dropped.
+    def is_bucket_too_old(self, bucket_timestamp):
+        """Check if a bucket is too old and should be dropped.
+        ;param bucket_timestamp: the bucket timestamp
+        :type bucket_timestamp: int
         :returns: bool
         """
-        oldest_bucket_timestamp = self.get_oldest_bucket_timestamp()
-        return (oldest_bucket_timestamp >= 0 and
-                oldest_bucket_timestamp <= self.timestamp - self.N)
+        return (bucket_timestamp >= 0 and
+                bucket_timestamp <= self.timestamp - self.N)
 
     def drop_oldest_bucket(self):
         """Drop oldest bucket timestamp."""

--- a/dgim/dgim.py
+++ b/dgim/dgim.py
@@ -62,7 +62,8 @@ class Dgim(object):
         :param elt: the latest element of the stream
         :type elt: int
         """
-        self.timestamp += 1
+        if self.N != 0:
+            self.timestamp = (self.timestamp + 1) % (2 * self.N)
         #check if oldest bucket should be removed
         if self.is_bucket_too_old(self.get_oldest_bucket_timestamp()):
             self.drop_oldest_bucket()
@@ -86,8 +87,9 @@ class Dgim(object):
         :type bucket_timestamp: int
         :returns: bool
         """
+        # the buckets are stored modulo 2 * N
         return (bucket_timestamp >= 0 and
-                bucket_timestamp <= self.timestamp - self.N)
+                (self.timestamp - bucket_timestamp) % (2 * self.N) >= self.N)
 
     def drop_oldest_bucket(self):
         """Drop oldest bucket timestamp."""

--- a/tests/test_dgim.py
+++ b/tests/test_dgim.py
@@ -87,3 +87,9 @@ class TestDgim(unittest.TestCase):
 
     def test_invalid_r(self):
         self.assertRaises(ValueError, Dgim, 10, 1)
+
+    def test_is_bucket_too_old(self):
+        dgim = Dgim(10)
+        dgim.timestamp = 100
+        self.assertFalse(dgim.is_bucket_too_old(91))
+        self.assertTrue(dgim.is_bucket_too_old(90))

--- a/tests/test_dgim.py
+++ b/tests/test_dgim.py
@@ -90,6 +90,11 @@ class TestDgim(unittest.TestCase):
 
     def test_is_bucket_too_old(self):
         dgim = Dgim(10)
-        dgim.timestamp = 100
-        self.assertFalse(dgim.is_bucket_too_old(91))
-        self.assertTrue(dgim.is_bucket_too_old(90))
+        dgim.timestamp = 15
+        self.assertFalse(dgim.is_bucket_too_old(6))
+        self.assertTrue(dgim.is_bucket_too_old(5))
+        self.assertTrue(dgim.is_bucket_too_old(16))
+
+        dgim.timestamp = 5
+        self.assertFalse(dgim.is_bucket_too_old(16))
+        self.assertTrue(dgim.is_bucket_too_old(15))


### PR DESCRIPTION
Store timestamps module 2*N to save memory on large streams.

Fix #4